### PR TITLE
Remove bundle config

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "/home/rowlandm/vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ _site/
 Gemfile.lock
 .sass-cache/
 *.swp
+.bundle/


### PR DESCRIPTION
While cloning locally and testing my jekyll install I ran into errors installing ruby bundles. Traced the error to system specific information in .bundle/config. Since this is a user/machine specific file it should not be added to Git. This PR removes it.